### PR TITLE
Cap CPU usage to 50% for bb containers to avoid blocking the host.

### DIFF
--- a/deployments/mainnet/docker-compose.yaml
+++ b/deployments/mainnet/docker-compose.yaml
@@ -110,6 +110,8 @@ services:
     networks:
       infura:
         ipv4_address: 10.2.0.111
+    # Use at most 50% of available CPU resources to not kill the host.
+    cpu_percent: 50
 
   bb_eth:
     container_name: bb_eth_mainnet
@@ -127,6 +129,8 @@ services:
     networks:
       infura:
         ipv4_address: 10.2.0.112
+    # Use at most 50% of available CPU resources to not kill the host.
+    cpu_percent: 50
 
   bb_bsc:
     container_name: bb_bsc_mainnet
@@ -144,6 +148,8 @@ services:
     networks:
       infura:
         ipv4_address: 10.2.0.113
+    # Use at most 50% of available CPU resources to not kill the host.
+    cpu_percent: 50
 
 networks:
   infura:


### PR DESCRIPTION
My pro-6-m instance would block completely, not even allowing SSH while running bb containers. This caps their CPU usage to 50% of whatever the machine has available, which is enough to keep up with sync but not kill the machine.

Docs:
https://github.com/compose-spec/compose-spec/blob/master/spec.md#cpu_percent
https://docs.docker.com/config/containers/resource_constraints/