### PR TITLE
Remove force reindex of BTC chain.

### DIFF
--- a/deployments/mainnet/docker-compose.yaml
+++ b/deployments/mainnet/docker-compose.yaml
@@ -54,7 +54,6 @@ services:
       -mempoolexpiry=12 
       -rpcworkqueue=600
       -txindex=1
-      -reindex
       -rpcuser=bitcoinrpc
       -rpcpassword=80vDUBXVMS4zH4Z+KjmBQuhKefsh0qNrBvM4G+ry0/48
     networks:


### PR DESCRIPTION
Otherwise, each restart of the bitcoind container triggers a full reindex.