### PR TITLE
Reduce mempool workers for less CPU load.

### DIFF
--- a/blockbooks/bitcoin/mainnet/blockchaincfg.json
+++ b/blockbooks/bitcoin/mainnet/blockchaincfg.json
@@ -14,7 +14,7 @@
     "xpub_magic_segwit_p2sh": 71979618,
     "xpub_magic_segwit_native": 73342198,
     "slip44": 1,
-    "mempool_workers": 8,
+    "mempool_workers": 2,
     "mempool_sub_workers": 2,
     "block_addresses_to_keep": 2147483647
 }


### PR DESCRIPTION
2 mempool workers did not affect sync speed in my testing, but it reduced the CPU load such that the Pro-6-M server did not hang anymore.